### PR TITLE
Add basic parsing of javadoc tags

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/ClassDocumentation.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/ClassDocumentation.java
@@ -170,11 +170,12 @@ public class ClassDocumentation {
 		return methodsJavadoc;
 	}
 
+	public Optional<String> getSummary() {
+		return Optional.ofNullable(javadocWrapper).flatMap(JavadocWrapper::getSummary);
+	}
+
 	public Optional<String> getDescription() {
-		if(javadocWrapper != null) {
-			return javadocWrapper.getDescription();
-		}
-		return Optional.empty();
+		return Optional.ofNullable(javadocWrapper).flatMap(JavadocWrapper::getDescription);
 	}
 
 	@Override

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocElementParser.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocElementParser.java
@@ -1,0 +1,103 @@
+package io.github.kbuntrock.javadoc;
+
+import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
+import com.github.javaparser.javadoc.description.JavadocInlineTag;
+import com.github.javaparser.javadoc.description.JavadocSnippet;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JavadocElementParser {
+
+	public static Optional<String> getSummary(JavadocDescription description, String endOfLineReplacement) {
+		return processJavadocElements(description, endOfLineReplacement, elements -> elements
+			.filter(onlyTagsOfType(JavadocTag.SUMMARY))
+			.map(JavadocElementParser::toTagContent));
+	}
+
+	public static Optional<String> getDescription(JavadocDescription description, String endOfLineReplacement1) {
+		return processJavadocElements(description, endOfLineReplacement1, elements -> elements
+			.filter(JavadocElementParser::onlySnippetsAndFormattingTags)
+			.map(JavadocElementParser::formatDescriptionElement));
+	}
+
+	private static Optional<String> processJavadocElements(
+		JavadocDescription description,
+		String endOfLineReplacement,
+		Function<Stream<JavadocDescriptionElement>, Stream<String>> elementProcessor) {
+		return Optional.ofNullable(description)
+			.map(JavadocDescription::getElements)
+			.map(Collection::stream)
+			.map(elementProcessor)
+			.map(s -> s.collect(Collectors.joining("\n")))
+			.map(s -> removeNewlinesIfActivated(s, endOfLineReplacement))
+			.filter(text -> !text.isEmpty())
+			.map(String::trim);
+	}
+
+	private static String formatDescriptionElement(JavadocDescriptionElement javadocElement) {
+		if(javadocElement instanceof JavadocInlineTag) {
+			JavadocInlineTag tag = (JavadocInlineTag) javadocElement;
+			switch(JavadocTag.fromString(tag.getName())) {
+				case CODE:
+					return toInlineCodeMarkdown(tag);
+				case SEE:
+					return toEmphasizedMarkdown(tag);
+				case LINK:
+					return toHrefMarkdown(tag);
+				default:
+					return tag.getContent();
+			}
+		}
+
+		return javadocElement.toText();
+	}
+
+	private static String toInlineCodeMarkdown(JavadocInlineTag tag) {
+		return "`" + tag.getContent().trim() + "`";
+	}
+
+	private static String toEmphasizedMarkdown(JavadocInlineTag tag) {
+		return "*" + tag.getContent().trim() + "*";
+	}
+
+	private static String toHrefMarkdown(JavadocInlineTag tag) {
+		Pattern p = Pattern.compile("href=\"(.*?)\"");
+		Matcher m = p.matcher(tag.getContent());
+		String url = null;
+		if(m.find()) {
+			url = m.group(1);
+		}
+		return String.format("[%s](%s)", url, url);
+	}
+
+	private static Predicate<JavadocDescriptionElement> onlyTagsOfType(JavadocTag tag) {
+		return e -> (e instanceof JavadocInlineTag && tag.toString().toLowerCase().equals(((JavadocInlineTag) e).getName()));
+	}
+
+	private static boolean onlySnippets(JavadocDescriptionElement e) {
+		return e instanceof JavadocSnippet;
+	}
+
+	private static String toTagContent(JavadocDescriptionElement t) {
+		return ((JavadocInlineTag) t).getContent().trim();
+	}
+
+	private static boolean onlySnippetsAndFormattingTags(JavadocDescriptionElement e) {
+		return onlySnippets(e) || (
+			e instanceof JavadocInlineTag &&
+				JavadocTag.isFormattingTag(((JavadocInlineTag) e).getName()));
+	}
+
+	private static String removeNewlinesIfActivated(String text, String endOfLineReplacement) {
+		return endOfLineReplacement != null
+			? text.replaceAll("\\r\\n", endOfLineReplacement).replaceAll("\\n", endOfLineReplacement)
+			: text;
+	}
+}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocParser.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocParser.java
@@ -7,7 +7,6 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
@@ -55,8 +54,7 @@ public class JavadocParser {
 			charset = Charset.forName(javadocConfiguration.getEncoding());
 		} else {
 			logger.warn("Encoding " + javadocConfiguration.getEncoding() + " is not supported. UTF-8 will be used instead.");
-			logger.warn("Supported encoding on this JVM are : " + Charset.availableCharsets().keySet().stream()
-				.collect(Collectors.joining(", ")));
+			logger.warn("Supported encoding on this JVM are : " + String.join(", ", Charset.availableCharsets().keySet()));
 		}
 		parserConfiguration.setCharacterEncoding(charset);
 		debugScan = javadocConfiguration.isDebugScan();
@@ -87,10 +85,12 @@ public class JavadocParser {
 			logger.debug("-------- PRINT JAVADOC SCAN RESULTS ----------");
 			for(final ClassDocumentation classDocumentation : javadocMap.values()) {
 				logger.debug("Class documentation for : " + classDocumentation.getCompleteName());
+				logger.debug("Summary : " + classDocumentation.getSummary());
 				logger.debug("Description : " + classDocumentation.getDescription());
 				if(!classDocumentation.getMethodsJavadoc().isEmpty()) {
 					for(final Entry<String, JavadocWrapper> entry : classDocumentation.getMethodsJavadoc().entrySet()) {
 						logger.debug("Method doc for : " + entry.getKey());
+						logger.debug("Summary : " + entry.getValue().getSummary());
 						logger.debug("Description : " + entry.getValue().getDescription());
 						entry.getValue().printParameters();
 						entry.getValue().printReturn();

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocTag.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocTag.java
@@ -1,0 +1,46 @@
+package io.github.kbuntrock.javadoc;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public enum JavadocTag {
+	// Tags with extractable information (content will be stripped from the general description)
+	SUMMARY,
+	AUTHOR,
+
+	// Formatting tags (text content should not be stripped)
+	CODE,
+	LINK,
+	SEE;
+
+	@Override
+	public String toString() {
+		return this.name().toLowerCase(Locale.ROOT);
+	}
+
+	public static JavadocTag fromString(String tagName) {
+		return JavadocTag.valueOf(tagName.toUpperCase(Locale.ROOT));
+	}
+
+	private static final HashSet<JavadocTag> formattingTags = new HashSet<>();
+
+	static {
+		formattingTags.add(CODE);
+		formattingTags.add(LINK);
+		formattingTags.add(SEE);
+	}
+
+	public static boolean isFormattingTag(String tagName) {
+		try {
+			JavadocTag tag = fromString(tagName);
+			return isFormattingTag(tag);
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	public static boolean isFormattingTag(JavadocTag tag) {
+		return formattingTags.contains(tag);
+	}
+}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocWrapper.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocWrapper.java
@@ -2,24 +2,13 @@ package io.github.kbuntrock.javadoc;
 
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
-import com.github.javaparser.javadoc.description.JavadocDescription;
-import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
-import com.github.javaparser.javadoc.description.JavadocInlineTag;
-import com.github.javaparser.javadoc.description.JavadocSnippet;
 import io.github.kbuntrock.utils.Logger;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Kevin Buntrock
@@ -81,17 +70,11 @@ public class JavadocWrapper {
 	}
 
 	public Optional<String> getSummary() {
-		return processJavadocElements(
-			elements -> elements
-				.filter(onlyTagsOfType(JavadocTag.SUMMARY))
-				.map(JavadocWrapper::toTagContent));
+		return JavadocElementParser.getSummary(javadoc.getDescription(), endOfLineReplacement);
 	}
 
 	public Optional<String> getDescription() {
-		return processJavadocElements(
-			elements -> elements
-				.filter(JavadocWrapper::onlySnippetsAndFormattingTags)
-				.map(JavadocWrapper::formatJavadocText));
+		return JavadocElementParser.getDescription(javadoc.getDescription(), endOfLineReplacement);
 	}
 
 	public boolean isInheritTagFound() {
@@ -105,74 +88,14 @@ public class JavadocWrapper {
 				Logger.INSTANCE.getLogger().debug(entry.getKey() + " : " + entry.getValue().getContent().toText());
 			}
 		}
-
 	}
 
 	public void printReturn() {
 		if(blockTagsByType != null) {
 			final Optional<JavadocBlockTag> returnTag = getReturnBlockTag();
-			if(returnTag.isPresent()) {
-				Logger.INSTANCE.getLogger().debug("Return : " + returnTag.get().getContent().toText());
-			}
+			returnTag.ifPresent(javadocBlockTag ->
+				Logger.INSTANCE.getLogger().debug("Return : " + javadocBlockTag.getContent().toText()));
 		}
 	}
 
-	private static String formatJavadocText(JavadocDescriptionElement javadocElement) {
-		if(javadocElement instanceof JavadocInlineTag) {
-			JavadocInlineTag tag = (JavadocInlineTag) javadocElement;
-			switch(JavadocTag.fromString(tag.getName())) {
-				case CODE:
-					return "`" + tag.getContent().trim() + "`";
-				case SEE:
-					return "*" + tag.getContent().trim() + "*";
-				case LINK:
-					Pattern p = Pattern.compile("href=\"(.*?)\"");
-					Matcher m = p.matcher(tag.getContent());
-					String url = null;
-					if (m.find()) {
-						url = m.group(1);
-					}
-					return "[" + url + "](" + url + ")";
-				default:
-					return tag.getContent();
-			}
-		}
-
-		return javadocElement.toText();
-	}
-
-	private Optional<String> processJavadocElements(Function<Stream<JavadocDescriptionElement>, Stream<String>> elementProcessor) {
-		return Optional.ofNullable(javadoc.getDescription())
-			.map(JavadocDescription::getElements)
-			.map(Collection::stream)
-			.map(elementProcessor)
-			.map(s -> s.collect(Collectors.joining("\n")))
-			.map(JavadocWrapper::removeNewlinesIfActivated)
-			.filter(text -> !text.isEmpty())
-			.map(String::trim);
-	}
-
-	private static Predicate<JavadocDescriptionElement> onlyTagsOfType(JavadocTag tag) {
-		return e -> (e instanceof JavadocInlineTag && tag.toString().toLowerCase().equals(((JavadocInlineTag) e).getName()));
-	}
-
-	private static boolean onlySnippetsAndFormattingTags(JavadocDescriptionElement e) {
-		return onlySnippets(e) || (
-			e instanceof JavadocInlineTag &&
-				JavadocTag.isFormattingTag(((JavadocInlineTag) e).getName()));
-	}
-
-	private static boolean onlySnippets(JavadocDescriptionElement e) {
-		return e instanceof JavadocSnippet;
-	}
-
-	private static String toTagContent(JavadocDescriptionElement t) {
-		return ((JavadocInlineTag) t).getContent().trim();
-	}
-
-	private static String removeNewlinesIfActivated(String text) {
-		return endOfLineReplacement != null
-			? text.replaceAll("\\r\\n", endOfLineReplacement).replaceAll("\\n", endOfLineReplacement)
-			: text;
-	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocWrapper.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocWrapper.java
@@ -2,13 +2,24 @@ package io.github.kbuntrock.javadoc;
 
 import com.github.javaparser.javadoc.Javadoc;
 import com.github.javaparser.javadoc.JavadocBlockTag;
+import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
+import com.github.javaparser.javadoc.description.JavadocInlineTag;
+import com.github.javaparser.javadoc.description.JavadocSnippet;
 import io.github.kbuntrock.utils.Logger;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Kevin Buntrock
@@ -69,17 +80,18 @@ public class JavadocWrapper {
 		return Optional.empty();
 	}
 
+	public Optional<String> getSummary() {
+		return processJavadocElements(
+			elements -> elements
+				.filter(onlyTagsOfType(JavadocTag.SUMMARY))
+				.map(JavadocWrapper::toTagContent));
+	}
+
 	public Optional<String> getDescription() {
-		if(javadoc.getDescription() != null) {
-			String desc = javadoc.getDescription().toText();
-			if(endOfLineReplacement != null) {
-				desc = desc.replaceAll("\\r\\n", endOfLineReplacement).replaceAll("\\n", endOfLineReplacement);
-			}
-			if(!desc.isEmpty()) {
-				return Optional.of(desc);
-			}
-		}
-		return Optional.empty();
+		return processJavadocElements(
+			elements -> elements
+				.filter(JavadocWrapper::onlySnippetsAndFormattingTags)
+				.map(JavadocWrapper::formatJavadocText));
 	}
 
 	public boolean isInheritTagFound() {
@@ -103,5 +115,64 @@ public class JavadocWrapper {
 				Logger.INSTANCE.getLogger().debug("Return : " + returnTag.get().getContent().toText());
 			}
 		}
+	}
+
+	private static String formatJavadocText(JavadocDescriptionElement javadocElement) {
+		if(javadocElement instanceof JavadocInlineTag) {
+			JavadocInlineTag tag = (JavadocInlineTag) javadocElement;
+			switch(JavadocTag.fromString(tag.getName())) {
+				case CODE:
+					return "`" + tag.getContent().trim() + "`";
+				case SEE:
+					return "*" + tag.getContent().trim() + "*";
+				case LINK:
+					Pattern p = Pattern.compile("href=\"(.*?)\"");
+					Matcher m = p.matcher(tag.getContent());
+					String url = null;
+					if (m.find()) {
+						url = m.group(1);
+					}
+					return "[" + url + "](" + url + ")";
+				default:
+					return tag.getContent();
+			}
+		}
+
+		return javadocElement.toText();
+	}
+
+	private Optional<String> processJavadocElements(Function<Stream<JavadocDescriptionElement>, Stream<String>> elementProcessor) {
+		return Optional.ofNullable(javadoc.getDescription())
+			.map(JavadocDescription::getElements)
+			.map(Collection::stream)
+			.map(elementProcessor)
+			.map(s -> s.collect(Collectors.joining("\n")))
+			.map(JavadocWrapper::removeNewlinesIfActivated)
+			.filter(text -> !text.isEmpty())
+			.map(String::trim);
+	}
+
+	private static Predicate<JavadocDescriptionElement> onlyTagsOfType(JavadocTag tag) {
+		return e -> (e instanceof JavadocInlineTag && tag.toString().toLowerCase().equals(((JavadocInlineTag) e).getName()));
+	}
+
+	private static boolean onlySnippetsAndFormattingTags(JavadocDescriptionElement e) {
+		return onlySnippets(e) || (
+			e instanceof JavadocInlineTag &&
+				JavadocTag.isFormattingTag(((JavadocInlineTag) e).getName()));
+	}
+
+	private static boolean onlySnippets(JavadocDescriptionElement e) {
+		return e instanceof JavadocSnippet;
+	}
+
+	private static String toTagContent(JavadocDescriptionElement t) {
+		return ((JavadocInlineTag) t).getContent().trim();
+	}
+
+	private static String removeNewlinesIfActivated(String text) {
+		return endOfLineReplacement != null
+			? text.replaceAll("\\r\\n", endOfLineReplacement).replaceAll("\\n", endOfLineReplacement)
+			: text;
 	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -140,26 +140,23 @@ public class YamlWriter {
 		specification.setTags(tagLibrary.getSortedTags().stream()
 			.map(x -> {
 				if(JavadocMap.INSTANCE.isPresent()) {
-					ClassDocumentation classDocumentation = JavadocMap.INSTANCE.getJavadocMap().get(x.getClazz().getCanonicalName());
+					ClassDocumentation classDocumentation = JavadocMap.INSTANCE.getJavadocMap()
+						.computeIfAbsent(x.getClazz().getCanonicalName(),
+							k -> new ClassDocumentation(x.getClazz().getCanonicalName(), x.getClazz().getSimpleName()));
 					// Even if there is no declared class documentation, we may enhance it with javadoc on interface and/or abstract classes
-					if(classDocumentation == null) {
-						classDocumentation = new ClassDocumentation(x.getClazz().getCanonicalName(), x.getClazz().getSimpleName());
-						JavadocMap.INSTANCE.getJavadocMap().put(x.getClazz().getCanonicalName(), classDocumentation);
-					}
-					logger.debug(
-						"Class documentation found for tag " + x.getClazz().getSimpleName() + " ? " + (classDocumentation != null));
+					logger.debug("Class documentation found for tag " + x.getClazz().getSimpleName());
 
 					classDocumentation.inheritanceEnhancement(x.getClazz(), ClassDocumentation.EnhancementType.METHODS);
-					final Optional<String> description = classDocumentation.getDescription();
-					if(description.isPresent()) {
-						return new TagElement(x.computeConfiguredName(apiConfiguration), description.get());
-					}
+					return new TagElement(
+						x.computeConfiguredName(apiConfiguration),
+						classDocumentation.getSummary().orElse(null),
+						classDocumentation.getDescription().orElse(null));
 				}
 
-				return new TagElement(x.computeConfiguredName(apiConfiguration), null);
+				return new TagElement(x.computeConfiguredName(apiConfiguration), null, null);
 			}).collect(Collectors.toList()));
 
-		// Write the "paths" section (all url / http verbs combinaison scanned)
+		// Write the "paths" section (all url / http verbs combination scanned)
 		specification.setPaths(createPaths(tagLibrary));
 
 		final Map<String, Object> schemaSection = createSchemaSection(tagLibrary);
@@ -229,8 +226,8 @@ public class YamlWriter {
 				final String computedTagName = tag.computeConfiguredName(apiConfiguration);
 				operation.getTags().add(computedTagName);
 				operation.setOperationId(ObjectsUtils.nonNullElse(endpoint.getOperationAnnotationInfo().getOperationId(),
-						apiConfiguration.getOperationIdHelper().toOperationId(tag.getName(), computedTagName, endpoint.getName()))
-					);
+					apiConfiguration.getOperationIdHelper().toOperationId(tag.getName(), computedTagName, endpoint.getName()))
+				);
 				if(apiConfiguration.isLoopbackOperationName()) {
 					operation.setLoopbackOperationName(endpoint.getName());
 				}
@@ -251,12 +248,16 @@ public class YamlWriter {
 					operation.setDescription(endpoint.getOperationAnnotationInfo().getDescription());
 				} else {
 					if(methodJavadoc != null) {
-						operation.setDescription(methodJavadoc.getJavadoc().getDescription().toText());
+						operation.setDescription(methodJavadoc.getDescription().orElse(null));
 					}
 				}
 
-				if(endpoint.getOperationAnnotationInfo().getDescription() != null) {
+				if(endpoint.getOperationAnnotationInfo().getSummary() != null) {
 					operation.setSummary(endpoint.getOperationAnnotationInfo().getSummary());
+				} else {
+					if(methodJavadoc != null) {
+						operation.setSummary(methodJavadoc.getSummary().orElse(null));
+					}
 				}
 
 				// Warning on paths
@@ -276,7 +277,8 @@ public class YamlWriter {
 
 				// All parameters which are not in the body
 				for(final ParameterObject parameter : endpoint.getParameters().stream()
-					.filter(x -> ParameterLocation.BODY != x.getLocation() && ParameterLocation.BODY_PART != x.getLocation()).collect(Collectors.toList())) {
+					.filter(x -> ParameterLocation.BODY != x.getLocation() && ParameterLocation.BODY_PART != x.getLocation())
+					.collect(Collectors.toList())) {
 					final ParameterElement parameterElement = new ParameterElement();
 					parameterElement.setName(parameter.getName());
 					parameterElement.setIn(parameter.getLocation().toString().toLowerCase(Locale.ENGLISH));
@@ -293,8 +295,8 @@ public class YamlWriter {
 					}
 					parameterElement.setSchema(schema);
 
-
-					if(parameter.getJavaClass() == Object.class && parameter.isAllowEmptyValue() && parameter.getLocation() == ParameterLocation.QUERY) {
+					if(parameter.getJavaClass() == Object.class && parameter.isAllowEmptyValue()
+						&& parameter.getLocation() == ParameterLocation.QUERY) {
 						parameterElement.setSchema(null);
 					}
 
@@ -324,6 +326,9 @@ public class YamlWriter {
 							if(javadocParamWrapper != null) {
 								final Optional<String> desc = javadocParamWrapper.getDescription();
 								parameterElement.setDescription(desc.get());
+
+								final Optional<String> summary = javadocParamWrapper.getSummary();
+								parameterElement.setSummary(summary.orElse(null));
 							}
 						}
 					}
@@ -345,7 +350,7 @@ public class YamlWriter {
 
 					final ParameterObject body = bodies.get(0);
 					final Content requestBodyContent = isFormData(bodies)
-					 	? Content.fromMultipartBodies(bodies)
+						? Content.fromMultipartBodies(bodies)
 						: Content.fromDataObject(body);
 
 					if(body.getFormats() != null) {
@@ -444,10 +449,11 @@ public class YamlWriter {
 
 	/**
 	 * Check if a common operation exist and merge it if possible
-	 * @param tag the tag to document
-	 * @param paths the already documented paths in this tag
+	 *
+	 * @param tag       the tag to document
+	 * @param paths     the already documented paths in this tag
 	 * @param operation the current operation to document
-	 * @param response the current operation response (without the default ones)
+	 * @param response  the current operation response (without the default ones)
 	 */
 	private void mergeCommonOperations(Tag tag, Map<String, Map<String, Operation>> paths, Operation operation, Response response) {
 		// Check if on operation already exist for this name (GET / POST / ...) and path
@@ -458,7 +464,7 @@ public class YamlWriter {
 			// Check if there is a collision in response content type.
 			Object existingContent = existingOperation.getResponses().get(response.getCode());
 			for(Entry<String, Content> responseContent : response.getContent().entrySet()) {
-				if(existingContent instanceof Response ) {
+				if(existingContent instanceof Response) {
 					Response existingResponse = (Response) existingContent;
 					if(existingResponse.getContent().containsKey(responseContent.getKey())) {
 						// There are too many cases: this is uncommon, but it might be a valid case.
@@ -482,13 +488,15 @@ public class YamlWriter {
 				}
 			}
 			// Now merging parameters
-			Map<String, ParameterElement> existingParametersByNames = existingOperation.getParameters().stream().collect(Collectors.toMap(ParameterElement::getName, Function.identity()));
+			Map<String, ParameterElement> existingParametersByNames = existingOperation.getParameters().stream()
+				.collect(Collectors.toMap(ParameterElement::getName, Function.identity()));
 			for(ParameterElement parameter : operation.getParameters()) {
 				ParameterElement existingParameter = existingParametersByNames.get(parameter.getName());
 				if(existingParameter == null) {
 					existingOperation.getParameters().add(parameter);
 				} else {
-					if(!existingParameter.getSchema().getType().getNode().toString().equals(parameter.getSchema().getType().getNode().toString())) {
+					if(!existingParameter.getSchema().getType().getNode().toString()
+						.equals(parameter.getSchema().getType().getNode().toString())) {
 						Logger.INSTANCE.getLogger().warn("Parameters incoherences detected in path " + operation.getPath());
 					}
 				}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/ParameterElement.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/ParameterElement.java
@@ -7,6 +7,8 @@ public class ParameterElement {
 
 	private String name;
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String summary;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String description;
 	private String in;
 	private boolean required;
@@ -53,6 +55,14 @@ public class ParameterElement {
 
 	public void setSchema(Property schema) {
 		this.schema = schema;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+
+	public void setSummary(String summary) {
+		this.summary = summary;
 	}
 
 	public String getDescription() {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
@@ -25,7 +25,6 @@ import io.github.kbuntrock.utils.OpenApiConstants;
 import io.github.kbuntrock.utils.OpenApiResolvedType;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
 import io.github.kbuntrock.utils.UnwrappingType;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -47,6 +46,8 @@ import org.apache.commons.lang3.StringUtils;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Schema {
 
+	@JsonIgnore
+	protected String summary;
 	@JsonIgnore
 	protected String description;
 	@JsonIgnore
@@ -199,6 +200,9 @@ public class Schema {
 								if(javadocWrapper != null) {
 									final Optional<String> desc = javadocWrapper.getDescription();
 									property.setDescription(desc.get());
+
+									final Optional<String> summary = javadocWrapper.getSummary();
+									property.setSummary(summary.orElse(null));
 								}
 							}
 						}
@@ -235,6 +239,9 @@ public class Schema {
 									if(javadocWrapper != null) {
 										final Optional<String> desc = javadocWrapper.getDescription();
 										property.setDescription(desc.get());
+
+										final Optional<String> summary = javadocWrapper.getSummary();
+										property.setSummary(summary.orElse(null));
 									}
 								}
 							}
@@ -394,6 +401,14 @@ public class Schema {
 
 	public void setItems(final Schema items) {
 		this.items = items;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+
+	public void setSummary(final String summary) {
+		this.summary = summary;
 	}
 
 	public String getDescription() {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/TagElement.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/TagElement.java
@@ -7,14 +7,18 @@ public class TagElement {
 	private String name;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String summary;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String description;
 
 	public TagElement() {
 
 	}
 
-	public TagElement(String name, String description) {
+	public TagElement(String name, String summary, String description) {
 		this.name = name;
+		this.summary = summary;
 		this.description = description;
 	}
 
@@ -24,6 +28,14 @@ public class TagElement {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+
+	public void setSummary(String summary) {
+		this.summary = summary;
 	}
 
 	public String getDescription() {

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/jackson/JacksonJsonPropertyController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/jackson/JacksonJsonPropertyController.java
@@ -16,10 +16,12 @@ import java.util.List;
 public interface JacksonJsonPropertyController {
 
     /**
-     * {@code GET  /users} : get the list of users
-     *
-     * @return the list of users.
-     */
+	 * {@code GET  /users} : get the list of users
+	 * {@see SimpleUserDto}
+	 * {@link <a href="https://kbuntrock.github.io/openapi-maven-plugin">https://kbuntrock.github.io/openapi-maven-plugin</a>}
+	 *
+	 * @return the list of users.
+	 */
     @RequestMapping(method = RequestMethod.GET)
     List<SimpleUserDto> findAll();
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/javadoc/inheritance/ChildClassOne.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/javadoc/inheritance/ChildClassOne.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * A beautiful description of ChildClassOne
+ * {@summary The first child}
+ * Subtitle
  *
  * @author Kevin Buntrock
  */
@@ -40,6 +42,7 @@ public class ChildClassOne extends ParentAbstract implements ParentInterface {
 
 	/**
 	 * Return the name of this controller
+	 * {@summary name getter}
 	 *
 	 * @return the name
 	 */

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_one.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_one.approved.txt
@@ -7,7 +7,8 @@ servers:
   - url: ""
 tags:
   - name: ChildClassOne
-    description: A beautiful description of ChildClassOne
+    summary: The first child
+    description: "A beautiful description of ChildClassOne\r\n\n\r\nSubtitle"
 paths:
   /api/child-class-one/can-encapsulate:
     get:
@@ -71,6 +72,7 @@ paths:
         - ChildClassOne
       operationId: getName
       description: Return the name of this controller
+      summary: name getter
       responses:
         200:
           description: the name

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.jacksonJsonProperty.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.jacksonJsonProperty.approved.txt
@@ -14,7 +14,8 @@ paths:
       tags:
         - JacksonJsonPropertyController
       operationId: findAll
-      description: "{@code GET  /users} : get the list of users"
+      description: "`GET  /users`\n : get the list of users\r\n\n*SimpleUserDto*\n\
+        \r\n\n[https://kbuntrock.github.io/openapi-maven-plugin](https://kbuntrock.github.io/openapi-maven-plugin)"
       responses:
         200:
           description: the list of users.


### PR DESCRIPTION
This PR adds the feature to parse javadoc tags in the following way:

- @summary -> goes into the summary field in yaml
- @code -> adds markdown tick marks to denote a piece of inline code
- @link -> adds markdown to generate a clickable link (so far only <a href> links)
- @see -> adds markdown to emphasize the content

The tag itself is stripped from the description

One thing might still need some fine tuning. At the moment, newlines are handled very weirdly. The code itself has a string field, to replace newlines with, but it is set to `null` by default. Therefore in my tests, I had several instances where it left \r\n in the description. I'll fix it in whichever way is preferred.